### PR TITLE
Added rtorrent.systemd file for systemd

### DIFF
--- a/rtorrent.systemd
+++ b/rtorrent.systemd
@@ -1,0 +1,28 @@
+# Systemd file for running rtorrent
+#
+# Copy this file to /etc/systemd/system/rtorrent.service
+#
+# To Enable Startup on boot run 
+#   - systemctl enable rtorrent.service
+#
+# To Start Service
+#   - systemctl start rtorrent.service
+#
+# Check Status
+#   - systemctl status rtorrent.service
+#
+# Change USERNAME for the user that will be running rtorrent
+#
+
+[Unit]
+Description=rTorrent
+
+[Service]
+Type=forking
+User=moe
+ExecStart=/usr/bin/screen -dm -S rtorrent /usr/local/bin/rtorrent -n -o import=/home/USERNAME/.config/rtorrent/rtorrent.rc
+ExecStop=/usr/bin/killall -w -s 2 /usr/local/bin/rtorrent
+WorkingDirectory=/home/USERNAME/.config/rtorrent/
+
+[Install]
+WantedBy=multi-user.target

--- a/rtorrent.systemd
+++ b/rtorrent.systemd
@@ -13,16 +13,18 @@
 #
 # Change USERNAME for the user that will be running rtorrent
 #
-
 [Unit]
 Description=rTorrent
+After=network.target
 
 [Service]
 Type=forking
+KillMode=none
 User=moe
-ExecStart=/usr/bin/screen -dm -S rtorrent /usr/local/bin/rtorrent -n -o import=/home/USERNAME/.config/rtorrent/rtorrent.rc
+ExecStart=/usr/bin/screen -d -m -fa -S rtorrent /usr/local/bin/rtorrent -n -o import=/home/moe/.config/rtorrent/rtorrent.rc
 ExecStop=/usr/bin/killall -w -s 2 /usr/local/bin/rtorrent
-WorkingDirectory=/home/USERNAME/.config/rtorrent/
+WorkingDirectory=/home/moe/
 
 [Install]
 WantedBy=multi-user.target
+

--- a/update-rutorrent
+++ b/update-rutorrent
@@ -9,7 +9,7 @@ plugins_svn="$rutorrent_svn/plugins"
 filemanager_svn="http://svn.rutorrent.org/svn/filemanager/trunk"
 mobile_svn="https://github.com/xombiemp/rutorrentMobile/trunk"
 
-plugins=(_getdir _noty2 _task autotools check_port chunks cookies create data datadir diskspace edit erasedata extratio filedrop geoip history httprpc loginmgr mediainfo ratio scheduler screenshots seedingtime source throttle tracklabels trafic unpack)
+plugins=(_getdir _noty2 _task autotools check_port chunks cookies create data datadir diskspace edit erasedata extratio filedrop geoip history httprpc loginmgr mediainfo ratio scheduler screenshots seedingtime source throttle tracklabels trafic unpack theme)
 hwk_plugins=(filemanager fileshare)
 
 updated="no"


### PR DESCRIPTION
I use Debian 8 (Jessie) which uses systemd.

I have added the file I use to start the rtorrent service.

Instructions on using the file are in the comments of the file.

This will work on any system that uses systemd.

Have also updated the update-rutorrent to include the missing theme plugin.
