### PR TITLE
Changed radarr.service loading mechanism for new version

### DIFF
--- a/radarr.service
+++ b/radarr.service
@@ -10,7 +10,7 @@ UMask=0002
 Type=simple
 KillMode=process
 Restart=always
-ExecStart=/usr/bin/mono --debug /opt/Radarr/Radarr.exe -nobrowser
+ExecStart=/opt/Radarr/Radarr -nobrowser
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I couldn't make a pull request for the wiki, so I just attached it here -> [Home.md](https://github.com/xombiemp/ultimate-torrent-setup/files/6605149/Home.md)

**I couldn't get Caddy to compile using the version of go and xcaddy that was included in the wiki, so in the "Install Prereqs" section I removed go-1.14 and added in the latest version from golang.org.  Please note what I included was an x64 version.  The radarr service that I changed later also includes an x64 version as the non-x64 version wouldn't start on ubuntu.  So if you decide to keep these you might want to update the assumptions to include x64.  The pull request is for the update to how Radarr starts with the new version.  I tested this all in a fresh new ubuntu 20.04 server.**

-sudo apt install -y git acl curl build-essential automake libtool libcppunit-dev libcurl4-openssl-dev libsigc++-2.0-dev libncurses5-dev zlib1g-dev libssl-dev libchromaprint-tools zip unzip rar unrar mediainfo ffmpeg php-fpm php-geoip php-curl php-mbstring python-is-python3 python3-setuptools golang-1.14
+sudo apt install -y git acl curl build-essential automake libtool libcppunit-dev libcurl4-openssl-dev libsigc++-2.0-dev libncurses5-dev zlib1g-dev libssl-dev libchromaprint-tools zip unzip rar unrar mediainfo ffmpeg php-fpm php-geoip php-curl php-mbstring python-is-python3 python3-setuptools

@@ -37,9 +37,19 @@ sudo adduser $USER media
 ### rTorrent
 Install Prereqs
 ```
-sudo ln -s /usr/lib/go-1.14/bin/go /usr/bin
+cd ~
+
+curl -LOJ https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
+
+tar -zxvf go1.16.5.linux-amd64.tar.gz
+
+sudo mv go /usr/lib/go-1.16.5/
+
+rm go1.16.5.linux-amd64.tar.gz
+
+sudo ln -s /usr/lib/go-1.16.5/bin/go /usr/bin

 ```

**Updating xcaddy from 0.1.5 to 0.1.9**

@@ -111,7 +121,7 @@ Install Caddy
 cd /usr/local/src

-sudo curl -LOJ https://github.com/caddyserver/xcaddy/releases/download/v0.1.5/xcaddy_0.1.5_linux_amd64.tar.gz
+sudo curl -LOJ https://github.com/caddyserver/xcaddy/releases/download/v0.1.9/xcaddy_0.1.9_linux_amd64.tar.gz

 sudo tar -xzvf xcaddy_*.tar.gz xcaddy


**There were actually 3 instances of this instead of two. Updated wiki to reflect that.**

@@ -215,7 +225,7 @@ Edit */etc/caddy/Caddyfile* and change the 4 instances of this to your actual do
 And change this to your actual email address.
 >youremailaddress@gmail.com

-And change the two instances of unix//var/run/php-fpm/php-fpm.sock to
+And change the three instances of unix//var/run/php-fpm/php-fpm.sock to
 >unix//run/php/php7.4-fpm.sock


**Couldn't get Radarr to start using the .linux.tar.gz.  Updated this to the linux-core-x64.tar.gz.**

 @@ -410,11 +420,11 @@ sudo adduser radarr media

 cd /opt

-sudo curl -L -O $( curl -s https://api.github.com/repos/Radarr/Radarr/releases | grep linux.tar.gz | grep browser_download_url | head -1 | cut -d \" -f 4 )
+sudo curl -L -O $( curl -s https://api.github.com/repos/Radarr/Radarr/releases | grep linux-core-x64.tar.gz | grep browser_download_url | head -1 | cut -d \" -f 4 )

-sudo tar -xvzf Radarr.*.linux.tar.gz
+sudo tar -xvzf Radarr.*.linux-core-x64.tar.gz

-sudo rm Radarr.*.linux.tar.gz
+sudo rm Radarr.*.linux-core-x64.tar.gz

 sudo chown -R radarr:media /opt/Radarr
